### PR TITLE
Remove note about using in template files or theme files because VIP use...

### DIFF
--- a/gumroad/views/admin.php
+++ b/gumroad/views/admin.php
@@ -62,11 +62,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<img src="https://s3.amazonaws.com/gumroad/assets/wordpress_docs/embeddemo.png">
 			</p>
 
-			<p>
-				<?php esc_html_e( 'Use the function', 'gum' ); ?> <code><?php echo htmlentities( '<?php echo do_shortcode(\'[gumroad id="DviQY"]\'); ?>' ); ?></code>
-				<?php esc_html_e( 'to display within template or theme files.', 'gum' ); ?>
-			</p>
-
 			<h4><?php esc_html_e( 'Available Attributes', 'gum' ); ?></h4>
 
 			<table class="widefat importers" cellspacing="0">


### PR DESCRIPTION
...rs will be unable to use this feature

From Wordpress:

> On the settings page, there's this line:
> Use the function <?php echo do_shortcode('[gumroad id="DviQY"]'); ?> to display within template or theme files."
> As a business user, they won't be able to add that, so we should remove this from the settings page so not to cause any confusion.

Also Phil, can Gumroad expect a transfer of the repo soon? We would appreciate that very much!