### PR TITLE
Automatically include gumroad.js on posts and pages with gumroad links.

### DIFF
--- a/gumroad/README.txt
+++ b/gumroad/README.txt
@@ -1,5 +1,5 @@
 === Gumroad ===
-Contributors: pderksen, nickyoung87, gumroad
+Contributors: karloscarweber, pderksen, nickyoung87, gumroad
 Tags: gumroad, gumroad product pages, gumroad overlay, gumroad embed, ecommerce, e-commerce, pdf, javascript, overlay, embed
 Requires at least: 3.9
 Tested up to: 4.9.6
@@ -69,6 +69,11 @@ See the official Gumroad [overlay](https://gumroad.com/overlay) or [embed](https
 
 == Changelog ==
 
+= 1.2.1 - December 11, 2018 =
+
+* Tested up to Wordpress 4.9.8
+* Posts with product links now automatically include gumroad.js
+
 = 1.2 =
 
 * Tested up to Wordpress 4.9.6
@@ -95,7 +100,7 @@ See the official Gumroad [overlay](https://gumroad.com/overlay) or [embed](https
 * Removed activation/install notice.
 * Removed some now unused functions and files.
 
-= 1.1.5 = 
+= 1.1.5 =
 
 * Videos added to in-plugin help page.
 * Demo videos added to Readme.txt.
@@ -105,7 +110,7 @@ See the official Gumroad [overlay](https://gumroad.com/overlay) or [embed](https
 
 * Added shortcode attribute to add CSS classes to the overlay link button.
 
-= 1.1.3 = 
+= 1.1.3 =
 
 * Added locale shortcode attribute.
 

--- a/gumroad/class-gumroad.php
+++ b/gumroad/class-gumroad.php
@@ -59,10 +59,10 @@ class Gumroad {
 	 * @since     1.0.0
 	 */
 	private function __construct() {
-		
+
 		// Load plugin text domain
 		add_action( 'plugins_loaded', array( $this, 'plugin_textdomain' ) );
-		
+
 		// Include required files.
 		add_action( 'init', array( $this, 'includes' ), 1 );
 
@@ -74,20 +74,20 @@ class Gumroad {
 
 		// Add plugin listing "Settings" action link.
 		add_filter( 'plugin_action_links_' . plugin_basename( plugin_dir_path( __FILE__ ) . $this->plugin_slug . '.php' ), array( $this, 'settings_link' ) );
-		
+
 		// Set our plugin constants
 		add_action( 'init', array( $this, 'setup_constants' ) );
 	}
-	
+
 	/**
-	 * Setup any plugin constants we need 
+	 * Setup any plugin constants we need
 	 *
 	 * @since    1.1.0
 	 */
 	public function setup_constants() {
 		define( 'GUM_PLUGIN_SLUG', $this->plugin_slug );
 	}
-	
+
 	/**
 	 * Load the plugin text domain for translation.
 	 *
@@ -100,7 +100,7 @@ class Gumroad {
 			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
 		);
 	}
-	
+
 	/**
 	 * Return an instance of this class.
 	 *
@@ -152,19 +152,22 @@ class Gumroad {
 	public function display_plugin_admin_page() {
 		include_once( 'views/admin.php' );
 	}
-	
+
 	/**
 	 * Include required files (admin and frontend).
 	 *
 	 * @since     1.0.1
 	 */
 	public function includes() {
-		
+
 		// Include any necessary functions
 		include_once( 'includes/misc-functions.php' );
-		
+
 		// Include shortcode functions
 		include_once( 'includes/shortcodes.php' );
+
+		// Include scanner functions
+		include_once( 'includes/scanner.php' );
 	}
 
 	/**

--- a/gumroad/gumroad.php
+++ b/gumroad/gumroad.php
@@ -4,10 +4,10 @@
  * Official Gumroad Wordpress Plugin
  *
  * @package   GUM
- * @author    Phil Derksen <pderksen@gmail.com>, Nick Young <mycorpweb@gmail.com>, Gumroad <hi@gumroad.com>
+ * @author    Karl Oscar Weber <me@kow.fm>, Phil Derksen <pderksen@gmail.com>, Nick Young <mycorpweb@gmail.com>, Gumroad <hi@gumroad.com>
  * @license   GPL-2.0+
  * @link      https://gumroad.com
- * @copyright 2013-2014 Gumroad
+ * @copyright 2013-2018 Gumroad
  *
  * @wordpress-plugin
  * Plugin Name: Gumroad

--- a/gumroad/includes/scanner.php
+++ b/gumroad/includes/scanner.php
@@ -1,0 +1,31 @@
+<?php
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Scanner
+ *
+ * The Scanner scans the post_content for gumroad links and then
+ * automatically include gumroad.js if it finds one.
+ */
+ function gum_post_scanner( $post_object ) {
+	 scanner($post_object->post_content);
+ }
+
+ /**
+  * Function accepts the post_content and scans it for gumroad short links
+	*
+	* @snce 1.2.1
+	*
+  */
+ function scanner( $post_content ) {
+ 	// counts to see if we find any gumroad product links.
+ 	if (count(preg_grep('/(gumroad.com\/l\/[[:alnum:]]|gum.co\/[[:alnum:]])/', explode("\n", $post_content))) > 0) {
+		gum_load_js('overlay');
+ 	}
+ }
+
+add_action('the_post', 'gum_post_scanner');

--- a/gumroad/includes/scanner.php
+++ b/gumroad/includes/scanner.php
@@ -22,10 +22,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	*
   */
  function scanner( $post_content ) {
+
  	// counts to see if we find any gumroad product links.
  	if (count(preg_grep('/(gumroad.com\/l\/[[:alnum:]]|gum.co\/[[:alnum:]])/', explode("\n", $post_content))) > 0) {
 		gum_load_js('overlay');
  	}
+	if (count(preg_grep('/(class=\"gumroad-product-embed\")/', explode("\n", $post_content))) > 0) {
+		gum_load_js('embed');
+	}
  }
 
 add_action('the_post', 'gum_post_scanner');

--- a/gumroad/views/admin.php
+++ b/gumroad/views/admin.php
@@ -41,10 +41,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'Please refer to the Overlay and Embed documentation for additional help:', 'gum' ); ?>
 				<a href="https://gumroad.com/overlay" target="_blank">Overlay Documentation</a>, <a href="https://gumroad.com/embed" target="_blank">Embed Documentation</a>
 			</p>
-			
+
 			<!-- Add a Gumroad product help -->
 
-			<h3 class="title"><?php esc_html_e( 'Adding a product page', 'gum' ); ?></h3>
+			<h3 class="title"><?php esc_html_e( 'Adding a product to a page', 'gum' ); ?></h3>
 
 			<p>
 				<?php esc_html_e( 'Use the shortcode', 'gum' ); ?> <code>[gumroad id="DviQY"]</code> <?php esc_html_e( 'to add a product link that will popup in an overlay', 'gum' ); ?>:
@@ -106,7 +106,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</tr>
 				</tbody>
 			</table>
-			
+
 			<h4><?php esc_html_e( 'More examples', 'gum' ); ?></h4>
 
 			<ul class="ul-disc">
@@ -115,6 +115,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<li><code>[gumroad id="DviQY" text="Comprar articulo" wanted="true" locale="true"]</code></li>
 				<p><img src="https://s3.amazonaws.com/gumroad/assets/wordpress_docs/wantedoverlaydemolocalized.gif"></p>
 			</ul>
+
+			<h3 class="title">Automatic linking and embeds</h3>
+
+			<p>Links to Gumroad products will automatically display an overlay on Gumroad pages. Embed code copied from the Gumroad product widget will also work without including the script tag:</p>
+
+			<p>
+<code>
+&lt;div class="gumroad-product-embed" data-gumroad-product-id="DviQY"&gt;&lt;a href="https://gumroad.com/l/qLlJJ"&gt;Loading...&lt;/a&gt;&lt;/div&gt;
+</code>
+			</p>
 
 		</div><!-- #gum-settings-content -->
 

--- a/gumroad/views/admin.php
+++ b/gumroad/views/admin.php
@@ -118,7 +118,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<h3 class="title">Automatic linking and embeds</h3>
 
-			<p>Links to Gumroad products will automatically display an overlay on Gumroad pages. Embed code copied from the Gumroad product widget will also work without including the script tag:</p>
+			<p>Links to Gumroad products will automatically trigger the overlay. Embed code copied from the Gumroad product widget will also work without including the script tag:</p>
 
 			<p>
 <code>


### PR DESCRIPTION
This pull request adds a scanner that scans each post or page for gumroad links and then automatically includes the gumroad.js javascript file on that page. It assumes that we want the overlay to display for these links.

solves issue #19 .