### PR TITLE
Fix: Version bump to 3.0.0 didn't work earlier

### DIFF
--- a/gumroad/class-gumroad.php
+++ b/gumroad/class-gumroad.php
@@ -21,7 +21,7 @@ class Gumroad {
 	 *
 	 * @var     string
 	 */
-	protected $version = '2.1.0';
+	protected $version = '3.0.0';
 
 	/**
 	 * Unique identifier for your plugin.

--- a/gumroad/gumroad.php
+++ b/gumroad/gumroad.php
@@ -13,7 +13,7 @@
  * Plugin Name: Gumroad
  * Plugin URI: https://gumroad.com
  * Description: Make your Gumroad products available for purchase right within WordPress.
- * Version: 2.1.0
+ * Version: 3.0.0
  * Author: Gumroad
  * Author URI: http://gumroad.com
  * License: GPL-2.0+


### PR DESCRIPTION
I noticed this while investigating a support ticket - https://gumroad.slack.com/archives/C01DBV0A257/p1637819015482800.

As discussed earlier in https://github.com/gumroad/wp-gumroad/pull/49/files#r623664602, it was supposed to work but it looks like it still shows 2.1.0 as the latest version at https://wordpress.org/plugins/gumroad instead of 3.0.0.

<img width="788" alt="image" src="https://user-images.githubusercontent.com/876195/144571383-7c95712b-92ba-46ca-9bbe-2a6c8bf7614d.png">

With these changes, it seems to update the version as intended on my local Wordpress setup.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/876195/144571870-7470ead1-ffdb-4c31-a515-9e8d3f1efbf9.png">

Hopefully, these changes would help the version to reflect correctly (thus allowing the plugin consumers to update it as well). 🤞 